### PR TITLE
Use .tif instead of .tiff for the temporary file name extension

### DIFF
--- a/NeatImage.py
+++ b/NeatImage.py
@@ -77,7 +77,7 @@ def plugin_main( image, drawable, visible ):
 
   tempdrawable = pdb.gimp_image_get_active_layer(tempimage)
   
-  tempfilename = os.path.join(tempfile.gettempdir(), "ShellOutTempFile.tiff" )
+  tempfilename = os.path.join(tempfile.gettempdir(), "ShellOutTempFile.tif" )
   
 
   # !!! Note no run-mode first parameter, and user entered filename is empty string


### PR DESCRIPTION
See https://www.reddit.com/r/GIMP/comments/d6334f/how_to_get_neatimagepy_to_pass_back_denoised - NeatImage seems to default to .tif when exporting, and sticking to that makes the re-import easier with additional user action.